### PR TITLE
Lf 46097

### DIFF
--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -8,15 +8,9 @@ logger = logging.getLogger(__name__)
 # d[year][month][day] example: 20200420
 ver_date = datetime.now().strftime("d%Y%m%d")
 
-_las_version = ""
-
 
 def version():
-    global _las_version
-
-    las_version = _las_version
-    if las_version:
-        return las_version
+    las_version = ""
 
     """
     Look for distribution version

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -51,7 +51,6 @@ def version():
     if not las_version.strip():
         las_version = "0.26.0.dev0+unknown-post-dist-version.{}".format(ver_date)
 
-    _las_version = las_version
     return las_version
 
 

--- a/lasio/las_version.py
+++ b/lasio/las_version.py
@@ -8,9 +8,15 @@ logger = logging.getLogger(__name__)
 # d[year][month][day] example: 20200420
 ver_date = datetime.now().strftime("d%Y%m%d")
 
+_las_version = ""
+
 
 def version():
-    las_version = ""
+    global _las_version
+
+    las_version = _las_version
+    if las_version:
+        return las_version
 
     """
     Look for distribution version
@@ -51,6 +57,7 @@ def version():
     if not las_version.strip():
         las_version = "0.26.0.dev0+unknown-post-dist-version.{}".format(ver_date)
 
+    _las_version = las_version
     return las_version
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 """Setup script for lasio"""
 
-import fileinput
 import lasio
-import re
 from setuptools import setup
 import os
 
-lasio_version = lasio.version()
-for line in fileinput.input('./lasio/__init__.py', inplace=True):
-   print(re.sub("^(__version__ = )version\(\)$", f'\g<1>\'{lasio_version}\'', line), end='')
+with open('./lasio/__init__.py', 'r') as f:
+    file_contents = f.read()
+
+changed_file_contents = file_contents.replace('__version__ = version()', f'__version__ = \'{lasio.version()}\'')
+
+with open('./lasio/__init__.py', 'w') as f:
+    file_contents = f.write(changed_file_contents)
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('./lasio/__init__.py', 'r') as f:
 changed_file_contents = file_contents.replace('__version__ = version()', f'__version__ = \'{lasio.version()}\'')
 
 with open('./lasio/__init__.py', 'w') as f:
-    file_contents = f.write(changed_file_contents)
+    f.write(changed_file_contents)
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup
 import os
 
 lasio_version = lasio.version()
-for line in fileinput.input('./lasio/las_version.py', inplace=True):
-   print(re.sub("^_las_version = \"\"$", f'_las_version = \'{lasio_version}\'', line), end='')
+for line in fileinput.input('./lasio/__init__.py', inplace=True):
+   print(re.sub("^(__version__ = )version\(\)$", f'\g<1>\'{lasio_version}\'', line), end='')
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ __init__file = os.path.join('lasio', '__init__.py')
 with open(__init__file, 'r') as f:
     file_contents = f.read()
 
-changed_file_contents = re.sub("__version__.+", f"__version__ = \'{lasio.version()}\'", file_contents)
+changed_file_contents, n = re.subn("__version__.+", f"__version__ = \'{lasio.version()}\'", file_contents)
 
-if changed_file_contents == file_contents:
-    raise Exception("Failed to replace version call with hardcoded value. See LF-46097")
+if n == 0:
+    raise Exception("Failed to find and replace the library version. See LF-46097")
 
 with open(__init__file, 'w') as f:
     f.write(changed_file_contents)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import lasio
 from setuptools import setup
 import os
 
-__init__file = './lasio/__init__.py'
+__init__file = os.path.join('lasio', '__init__.py')
 with open(__init__file, 'r') as f:
     file_contents = f.read()
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __init__file = os.path.join('lasio', '__init__.py')
 with open(__init__file, 'r') as f:
     file_contents = f.read()
 
-changed_file_contents = re.sub(r"(__version__\s?=\s?)[\"\'\w()]+", fr"""\g<1>'{lasio.version()}'""", file_contents)
+changed_file_contents = re.sub("__version__.*", f"___version___ = \'{lasio.version()}\'", file_contents)
 
 if changed_file_contents == file_contents:
     raise Exception("Failed to replace version call with hardcoded value. See LF-46097")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """Setup script for lasio"""
 
 import lasio
+import re
 from setuptools import setup
 import os
 
@@ -8,7 +9,10 @@ __init__file = os.path.join('lasio', '__init__.py')
 with open(__init__file, 'r') as f:
     file_contents = f.read()
 
-changed_file_contents = file_contents.replace('__version__ = version()', f'__version__ = \'{lasio.version()}\'')
+changed_file_contents = re.sub(r"(__version__\s?=\s?)[\"\'\w()]+", fr"""\g<1>'{lasio.version()}'""", file_contents)
+
+if changed_file_contents == file_contents:
+    raise Exception("Failed to replace version call with hardcoded value. See LF-46097")
 
 with open(__init__file, 'w') as f:
     f.write(changed_file_contents)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 """Setup script for lasio"""
 
+import fileinput
+import lasio
+import re
 from setuptools import setup
 import os
+
+lasio_version = lasio.version()
+for line in fileinput.input('./lasio/las_version.py', inplace=True):
+   print(re.sub("^_las_version = \"\"$", f'_las_version = {lasio_version}', line), end='')
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,23 @@
 """Setup script for lasio"""
 
-import lasio
 import re
 from setuptools import setup
 import os
 
-__init__file = os.path.join('lasio', '__init__.py')
-with open(__init__file, 'r') as f:
-    file_contents = f.read()
+if 'LASIO_VERSION' in os.environ:
+    lasio_version = os.environ['LASIO_VERSION']
+    __init__file = os.path.join('lasio', '__init__.py')
 
-changed_file_contents, n = re.subn("__version__.+", f"__version__ = \'{lasio.version()}\'", file_contents)
+    with open(__init__file, 'r') as f:
+        file_contents = f.read()
 
-if n == 0:
-    raise Exception("Failed to find and replace the library version. See LF-46097")
+    changed_file_contents, n = re.subn("__version__.+", f"__version__ = \'{lasio_version}\'", file_contents)
 
-with open(__init__file, 'w') as f:
-    f.write(changed_file_contents)
+    if n == 0:
+        raise Exception("Failed to find and replace the library version. See LF-46097")
+
+    with open(__init__file, 'w') as f:
+        f.write(changed_file_contents)
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 
 lasio_version = lasio.version()
 for line in fileinput.input('./lasio/las_version.py', inplace=True):
-   print(re.sub("^_las_version = \"\"$", f'_las_version = {lasio_version}', line), end='')
+   print(re.sub("^_las_version = \"\"$", f'_las_version = \'{lasio_version}\'', line), end='')
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")
 TEST_REQS = (

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ import lasio
 from setuptools import setup
 import os
 
-with open('./lasio/__init__.py', 'r') as f:
+__init__file = './lasio/__init__.py'
+with open(__init__file, 'r') as f:
     file_contents = f.read()
 
 changed_file_contents = file_contents.replace('__version__ = version()', f'__version__ = \'{lasio.version()}\'')
 
-with open('./lasio/__init__.py', 'w') as f:
+with open(__init__file, 'w') as f:
     f.write(changed_file_contents)
 
 EXTRA_REQS = ("pandas", "cchardet", "openpyxl")

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __init__file = os.path.join('lasio', '__init__.py')
 with open(__init__file, 'r') as f:
     file_contents = f.read()
 
-changed_file_contents = re.sub("__version__.*", f"___version___ = \'{lasio.version()}\'", file_contents)
+changed_file_contents = re.sub("__version__.+", f"__version__ = \'{lasio.version()}\'", file_contents)
 
 if changed_file_contents == file_contents:
     raise Exception("Failed to replace version call with hardcoded value. See LF-46097")


### PR DESCRIPTION
LF-46097 Replace version to string during build process.

- When setup.py is executed during the build process, manually change the version inside of the __init__ to not
  call the version() method.
- This is important because without it, when a new background process is spawned and the library is imported it will attempt to 
  fetch the version using package resources. Package resources will fail to retrieve the correct version due to our packaging 
  structure. After it fails lasio has custom code to fetch the version using the command "git describe --tags --match v*", which 
  spawns a command prompt window.